### PR TITLE
Allow the removal of group permissions from a repository

### DIFF
--- a/bb-repo-config.yml
+++ b/bb-repo-config.yml
@@ -247,7 +247,7 @@
           - 201
       when:
         - "limit_bb_repo is not defined or item.0.name == limit_bb_repo"
-        - item.1.state != 'present' or item.1.state == 'NA'
+        - "item.1.state != 'present' or item.1.state == 'NA'"
       loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
       loop_control:
         label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"

--- a/bb-repo-config.yml
+++ b/bb-repo-config.yml
@@ -264,7 +264,9 @@
         status_code:
           - 200
           - 201
-      when: "item.1.state == 'absent'"
+      when:
+        - "limit_bb_repo is not defined or item.0.name == limit_bb_repo"
+        - "item.1.state == 'absent'"
       loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
       loop_control:
         label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"

--- a/bb-repo-config.yml
+++ b/bb-repo-config.yml
@@ -247,7 +247,7 @@
           - 201
       when:
         - "limit_bb_repo is not defined or item.0.name == limit_bb_repo"
-        - "item.1.state != 'present' or item.1.state == 'NA'"
+        - "item.1.state == 'present' or item.1.state is not defined"
       loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
       loop_control:
         label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"

--- a/bb-repo-config.yml
+++ b/bb-repo-config.yml
@@ -245,7 +245,26 @@
         status_code:
           - 200
           - 201
-      when: "limit_bb_repo is not defined or item.0.name == limit_bb_repo"
+      when:
+        - "limit_bb_repo is not defined or item.0.name == limit_bb_repo"
+        - item.1.state != 'present' or item.1.state == 'NA'
+      loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
+      loop_control:
+        label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"
+      tags: [ 'bb_permissions' ]
+    
+    - name: "Remove repo permissions"
+      uri:
+        url: "https://api.bitbucket.org/1.0/group-privileges/{{ bb_workspace }}/{{ item.0.name }}/{{ bb_workspace }}/{{ item.1.group_slug }}"
+        method: DELETE
+        user: "{{  bb_user }}"
+        password: "{{  bb_apitoken }}"
+        force_basic_auth: yes
+        body: "{{ item.1.privilege }}"
+        status_code:
+          - 200
+          - 201
+      when: "item.1.state == 'absent'"
       loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
       loop_control:
         label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"

--- a/bb-repo-config.yml
+++ b/bb-repo-config.yml
@@ -269,7 +269,7 @@
         - "item.1.state == 'absent'"
       loop: "{{ q('subelements', repos, 'group_permissions', {'skip_missing': True}) }}"
       loop_control:
-        label: "Grant group {{ item.1.group_slug }} {{ item.1.privilege }} access on repository {{ item.0.name }}"
+        label: "Revoke group {{ item.1.group_slug }} {{ item.1.privilege }} access from repository {{ item.0.name }}"
       tags: [ 'bb_permissions' ]
 
     - name: "Always grant the default-reviewers group RW access to the repo"


### PR DESCRIPTION
using `state: "absent"` in your code will remove the group from the repository

if you use `state: "present"` or you don't enter the `state` variable, it will add the permissions to the repository

from: https://support.atlassian.com/bitbucket-cloud/docs/group-privileges-endpoint/
**DELETE privileges for a group across all your repositories**
```
DELETE https://api.bitbucket.org/1.0/group-privileges/{workspace_id}/group_owner}/{group_slug}
```
